### PR TITLE
Use git sha in circle ci cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           name: docker save app:build
           command: mkdir -p /cache; docker save -o /cache/docker.tar "app:build"
       - save_cache:
-          key: v1-{{ .Branch }}-{{epoch}}
+          key: v1-{{ .Environment.CIRCLE_SHA1 }}-{{epoch}}
           paths:
             - /cache/docker.tar
 
@@ -45,7 +45,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{.Branch}}
+          key: v1-{{.Environment.CIRCLE_SHA1}}
       - run:
           name: Restore Docker image cache
           command: docker load -i /cache/docker.tar
@@ -60,7 +60,7 @@ jobs:
     steps:
       - setup_remote_docker
       - restore_cache:
-          key: v1-{{.Branch}}
+          key: v1-{{.Environment.CIRCLE_SHA1}}
       - run:
           name: Restore Docker image cache
           command: docker load -i /cache/docker.tar


### PR DESCRIPTION
Yesterday, the contents of the image we had autodeployed to stage did match what we expected.

Ordered by workflow, here is what seems to have happened

workflow 58 build 144 built an image for a22f2d9, which adds tag 0.0.5, and logged "Stored Cache to v1--1599842496"
workflow 58 build 148 logged "Found a cache from build 144 at v1-", restored 4ea2177f, and ran tests against it
workflow 58 build 149 logged "Found a cache from build 146 at v1-", restored b9bf2ad5 and pushed it to dockerhub as 0.0.5

workflow 59 build 146 built an image for commit 994c5aa, an unmerged PR bumping dependencies, and logged "Stored Cache to v1-renovate/pin-dependencies-1599842530"
workflow 59 build 150 logged "Found a cache from build 146 at v1-renovate/pin-dependencies", restored b9bf2ad5, and ran tests against it

So workflow 58 (the tag on master branch) and 59 (the PR) ran concurrently, and the last step of 58 which pushes the image to dockerhub restored and pushed an image from 59 instead.

Tis happened because we say to

```
- save_cache:
  key: v1-{{ .Branch }}-{{epoch}}

- restore_cache:
  key: v1-{{.Branch}}
```

and for master the is no branch, so the key is just v1-. CircleCI docs say that

> A key is searched against existing keys as a prefix.
> Note: When there are multiple matches, the most recent match will be used, even if there is a more precise match

Build 149 had the choice of restoring either the cache "v1--1599842496" from build 144 or the cache "v1-renovate/pin-dependencies" from build 146. Consistent with the docs it chose the latter, even though its from a different workflow.

With this PR, the caches would have been named "v1-a22f2d9-1599842496" and "v1-994c5aa-1599842530". We would have tried to restore "v1-a22f2d9" so we would have selected the right one.