### PR TITLE
Lock specific node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:12.18.4-slim
 
 # add a non-privileged user for running the application
 RUN groupadd --gid 10001 app && \


### PR DESCRIPTION
Renovate should bump this for us whenever there is a new release

https://docs.renovatebot.com/docker/