### PR TITLE
Region mismatch workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1849,6 +1849,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@sentry/node": "^5.15.5",
     "express": "4.17.1",
-    "mozlog": "3.0.1"
+    "mozlog": "3.0.1",
+    "psl": "^1.8.0"
   },
   "devDependencies": {
     "mocha": "8.2.1",

--- a/server.js
+++ b/server.js
@@ -195,7 +195,6 @@ app.use("/cid/:cid", (req, res) => {
   }
 
   let target = createTarget(req, campaign);
-
   log.info("server", { msg: `forwarding ${cid} to ${target}` });
 
   forwardRequest(req, res, {

--- a/server.js
+++ b/server.js
@@ -116,11 +116,12 @@ const createTarget = (req, options) => {
 
     // TEMP WORKAROUND: if the region passed in the X-Region header doesn't
     // match up with the region that the public suffix indicates, throw an error.
+    // When https://bugzilla.mozilla.org/show_bug.cgi?id=1685729 is resolved and
+    // released, this code may be removed.
     let XRegion = req.headers["x-region"];
-    if (tld && XRegion && PUBLIC_SUFFIX_TO_REGION.has(tld)) {
-      if (PUBLIC_SUFFIX_TO_REGION.get(tld) != XRegion.toLowerCase()) {
-        throw new Error(ERR_REGION_MISMATCH);
-      }
+    if (tld && XRegion && PUBLIC_SUFFIX_TO_REGION.has(tld) &&
+      PUBLIC_SUFFIX_TO_REGION.get(tld) != XRegion.toLowerCase()) {
+      throw new Error(ERR_REGION_MISMATCH);
     }
 
     // Support the eBay campaign.

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
+const express = require("express");
 const fs = require("fs");
 const forwardRequest = require("./lib/forward-request");
-const express = require("express");
+const psl = require("psl");
 const sentry = require("@sentry/node");
 
 const mozlog = require("mozlog")({
@@ -66,6 +67,15 @@ const CONFIG = {
     }
   },
 };
+const PUBLIC_SUFFIX_TO_REGION = new Map([
+  ["ca", "ca"],
+  ["co.uk", "gb"],
+  ["com.au", "au"],
+  ["com", "us"],
+  ["de", "de"],
+  ["fr", "fr"]
+]);
+const ERR_REGION_MISMATCH = "Public suffix region mismatch.";
 
 /**
  * Constructs the URL to be fetched via this proxy. First, we merge pre-defined
@@ -95,9 +105,34 @@ const createTarget = (req, options) => {
   }
 
   let XTargetURL = req.headers["x-target-url"];
-  // Support the eBay campaign.
-  if (XTargetURL && XTargetURL.startsWith("https://www.ebay.")) {
-    options.query.sub1 = "ebay";
+  let url, tld;
+  if (XTargetURL) {
+    try {
+      url = new URL(paramValue);
+      {tld} = psl.parse(url.hostname);
+    } catch (ex) {
+      log.info("server", {msg: "Invalid URL passed for X-Target-URL: " + paramValue});
+    }
+
+    // TEMP WORKAROUND: if the region passed in the X-Region header doesn't
+    // match up with the region that the public suffix indicates, throw an error.
+    let XRegion = req.headers["x-region"];
+    if (PUBLIC_SUFFIX_TO_REGION.has(tld)) {
+      if (PUBLIC_SUFFIX_TO_REGION.get(tld) != XRegion) {
+        throw new Error(ERR_REGION_MISMATCH);
+      }
+    }
+
+    // Support the eBay campaign.
+    if (XTargetURL.startsWith("https://www.ebay.")) {
+      options.query.sub1 = "ebay";
+    }
+
+    // Extract the `ctag` parameter from the target URL.
+    let tag = url.searchParams.get("ref") || url.searchParams.get("crlp");
+    if (tag) {
+      query.push("ctag=" + encodeURIComponent(tag.replace("pd_sl_a", "")));
+    }
   }
 
   if (options.url == process.env["WEATHER_CONDITIONS_URL"]) {
@@ -118,19 +153,6 @@ const createTarget = (req, options) => {
         let header = parts[1];
         paramValue = (req.headers[header] || "");
         if (header == "x-target-url") {
-          // Extract the `ctag` parameter from the target URL.
-          if (paramValue) {
-            let url;
-            try {
-              url = new URL(paramValue);
-            } catch (ex) {
-              log.info("server", {msg: "Invalid URL passed for X-Target-URL: " + paramValue});
-            }
-            let tag = url.searchParams.get("ref") || url.searchParams.get("crlp");
-            if (tag) {
-              query.push("ctag=" + encodeURIComponent(tag.replace("pd_sl_a", "")));
-            }
-          }
           paramValue = encodeURIComponent(paramValue);
         } else {
           paramValue = paramValue.toLowerCase();
@@ -173,6 +195,7 @@ app.use("/cid/:cid", (req, res) => {
   }
 
   let target = createTarget(req, campaign);
+
   log.info("server", { msg: `forwarding ${cid} to ${target}` });
 
   forwardRequest(req, res, {
@@ -218,7 +241,8 @@ app.use(sentry.Handlers.errorHandler());
 app.use(function errorHandler(err, req, res, next) {
   let msg = err + "";
   log.error("server", { msg });
-  res.status(500).send({
+  // If we detected a region mismatch, mark the request with a different code.
+  res.status(msg.includes(ERR_REGION_MISMATCH) ? 412 : 500).send({
     status: "error",
     "details": {
       msg,

--- a/server.js
+++ b/server.js
@@ -108,16 +108,16 @@ const createTarget = (req, options) => {
   let url, tld;
   if (XTargetURL) {
     try {
-      url = new URL(paramValue);
-      {tld} = psl.parse(url.hostname);
+      url = new URL(XTargetURL);
+      tld = psl.parse(url.hostname).tld;
     } catch (ex) {
-      log.info("server", {msg: "Invalid URL passed for X-Target-URL: " + paramValue});
+      log.info("server", {msg: "Invalid URL passed for X-Target-URL: " + XTargetURL});
     }
 
     // TEMP WORKAROUND: if the region passed in the X-Region header doesn't
     // match up with the region that the public suffix indicates, throw an error.
     let XRegion = req.headers["x-region"];
-    if (PUBLIC_SUFFIX_TO_REGION.has(tld)) {
+    if (tld && PUBLIC_SUFFIX_TO_REGION.has(tld)) {
       if (PUBLIC_SUFFIX_TO_REGION.get(tld) != XRegion) {
         throw new Error(ERR_REGION_MISMATCH);
       }

--- a/server.js
+++ b/server.js
@@ -117,8 +117,8 @@ const createTarget = (req, options) => {
     // TEMP WORKAROUND: if the region passed in the X-Region header doesn't
     // match up with the region that the public suffix indicates, throw an error.
     let XRegion = req.headers["x-region"];
-    if (tld && PUBLIC_SUFFIX_TO_REGION.has(tld)) {
-      if (PUBLIC_SUFFIX_TO_REGION.get(tld) != XRegion) {
+    if (tld && XRegion && PUBLIC_SUFFIX_TO_REGION.has(tld)) {
+      if (PUBLIC_SUFFIX_TO_REGION.get(tld) != XRegion.toLowerCase()) {
         throw new Error(ERR_REGION_MISMATCH);
       }
     }

--- a/test/test_forwarding.js
+++ b/test/test_forwarding.js
@@ -146,8 +146,8 @@ describe("Top Sites forward request endpoint", function() {
       });
 
       Assert.ok(data);
-      Assert.equal(data.trim(), "TEST: /test?sub1=ebay&key=xxx&cuid=" +
-        cid + "&h1=uk&h2=newtab&ctag=123456789GB2020110611&cu=" + encodeURIComponent(targetURL));
+      Assert.equal(data.trim(), "TEST: /test?ctag=123456789GB2020110611&sub1=ebay&" +
+        "key=xxx&cuid=" + cid + "&h1=uk&h2=newtab&cu=" + encodeURIComponent(targetURL));
 
       // Sanity check that the configuration is not mutated and subsequent
       // requests still work.

--- a/test/test_region_mismatch.js
+++ b/test/test_region_mismatch.js
@@ -1,0 +1,166 @@
+const Assert = require("assert");
+const { withServer, sendForwardRequest, PORT, STOP } = require("./utils");
+
+describe("Top Sites forward request endpoint - region mismatches", function() {
+
+  it("should fail requests with non-matching regions", async function() {
+    return withServer(async server => {
+      const cid = "amzn_2020_1";
+      let data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "de",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.ca"
+        },
+        expectedStatusCode: 412,
+        waitForServerLogMessage: "region mismatch"
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "ca",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.co.uk"
+        },
+        expectedStatusCode: 412,
+        waitForServerLogMessage: "region mismatch"
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "gb",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.com.au"
+        },
+        expectedStatusCode: 412,
+        waitForServerLogMessage: "region mismatch"
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "ca",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.com"
+        },
+        expectedStatusCode: 412,
+        waitForServerLogMessage: "region mismatch"
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "fr",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.de"
+        },
+        expectedStatusCode: 412,
+        waitForServerLogMessage: "region mismatch"
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "de",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.fr"
+        },
+        expectedStatusCode: 412,
+        waitForServerLogMessage: "region mismatch"
+      });
+
+      Assert.ok(data);
+    });
+  });
+
+  it("should should forward requests that have matching regions (sanity check)", async function() {
+    return withServer(async server => {
+      const cid = "amzn_2020_1";
+      let data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "ca",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.ca"
+        },
+        waitForServerLogMessage: `forwarding ${cid} to `
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "gb",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.co.uk"
+        },
+        waitForServerLogMessage: `forwarding ${cid} to `
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "au",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.com.au"
+        },
+        waitForServerLogMessage: `forwarding ${cid} to `
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "us",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.com"
+        },
+        waitForServerLogMessage: `forwarding ${cid} to `
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "de",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.de"
+        },
+        waitForServerLogMessage: `forwarding ${cid} to `
+      });
+
+      Assert.ok(data);
+
+      data = await sendForwardRequest(server, {
+        url: `http://localhost:${PORT}/cid/${cid}`,
+        headers: {
+          "X-Region": "fr",
+          "X-Source": "newtab",
+          "X-Target-URL": "https://www.example.fr"
+        },
+        waitForServerLogMessage: `forwarding ${cid} to `
+      });
+
+      Assert.ok(data);
+    });
+  });
+
+});


### PR DESCRIPTION
Greg! It's me again 😅 

This is a temporary workaround to make sure our partner(s) don't get requests forwarded with non-matching regions. The added test file should tell the whole story, but in words here:
Sometimes Firefox sends a request to report a click on a `foo.com` tile with `ca` in the `X-Region` header, which is not something our partner(s) expects. We're fixing this on the client too - we should show the correct tiles based on the user's home region - so this is a stop-gap.
The alternate HTTP status code will allow us to monitor the daily occurrences on the load balancer dashboard, since we don't log anything on the server. Note that the LB also doesn't persist these no longer than two weeks, but it's better than nothing 😉 