### PR TITLE
Bug 1687811 - Encode "q" parameters.

### DIFF
--- a/server.js
+++ b/server.js
@@ -159,6 +159,9 @@ const createTarget = (req, options) => {
 
   for (let paramName of Object.getOwnPropertyNames(options.query)) {
     let paramValue = options.query[paramName];
+    if (paramName == "q") {
+      paramValue = encodeURIComponent(paramValue);
+    }
     let parts = paramValue.toLowerCase().split(SPECIAL_ARG_REGEXP);
     if (parts.length >= 3 && !parts.pop() && !parts.shift()) {
       if (parts[0] == "header") {


### PR DESCRIPTION
`q` parameters are usually understood to be human-readable query strings. We can better handle non-ASCII characters if we encode these strings.

I considered making the check `if (paramName == "q" && options.url == process.env["WEATHER_LOCATION_URL"])` but I think encoding would be useful to other consumers sending a `q` parameter in the future.